### PR TITLE
Fix Crawler not throwing FatalHandlerException

### DIFF
--- a/src/main/java/ai/preferred/venom/Crawler.java
+++ b/src/main/java/ai/preferred/venom/Crawler.java
@@ -439,7 +439,9 @@ public final class Crawler implements Interruptible {
    */
   private void interrupt() throws Exception {
     exitWhenDone.set(true);
-    crawlerThread.interrupt();
+    if (!Thread.currentThread().equals(crawlerThread)) {
+      crawlerThread.interrupt();
+    }
     threadPool.shutdownNow();
 
     Exception cachedException = null;

--- a/src/main/java/ai/preferred/venom/Crawler.java
+++ b/src/main/java/ai/preferred/venom/Crawler.java
@@ -469,7 +469,7 @@ public final class Crawler implements Interruptible {
 
       Exception cachedException = null;
       for (final AutoCloseable closeable : new AutoCloseable[]{workerManager, fetcher}) {
-        if (Thread.interrupted()) {
+        if (Thread.interrupted() && interrupted.compareAndSet(false, true)) {
           interrupt();
         }
 

--- a/src/main/java/ai/preferred/venom/Crawler.java
+++ b/src/main/java/ai/preferred/venom/Crawler.java
@@ -469,6 +469,10 @@ public final class Crawler implements Interruptible {
 
       Exception cachedException = null;
       for (final AutoCloseable closeable : new AutoCloseable[]{workerManager, fetcher}) {
+        if (Thread.interrupted()) {
+          interrupt();
+        }
+
         try {
           closeable.close();
         } catch (InterruptedException e) {

--- a/src/main/java/ai/preferred/venom/Crawler.java
+++ b/src/main/java/ai/preferred/venom/Crawler.java
@@ -377,11 +377,7 @@ public final class Crawler implements Interruptible {
     }
     if (!fatalHandlerExceptions.isEmpty()) {
       LOGGER.debug("Handler exception found... Interrupting.");
-      try {
-        interrupt();
-      } catch (final Exception e) {
-        throw new RuntimeException(e);
-      }
+      interrupt();
     }
     LOGGER.debug("({}) will stop producing requests.", crawlerThread.getName());
   }

--- a/src/main/java/ai/preferred/venom/Crawler.java
+++ b/src/main/java/ai/preferred/venom/Crawler.java
@@ -430,7 +430,6 @@ public final class Crawler implements Interruptible {
    */
   @Override
   public void interrupt() {
-    exitWhenDone.set(true);
     if (!Thread.currentThread().equals(crawlerThread)) {
       crawlerThread.interrupt();
     }

--- a/src/main/java/ai/preferred/venom/Interruptible.java
+++ b/src/main/java/ai/preferred/venom/Interruptible.java
@@ -19,13 +19,16 @@ package ai.preferred.venom;
 /**
  * @author Ween Jiann Lee
  */
-public interface Interruptible extends AutoCloseable {
+public interface Interruptible {
 
   /**
    * Interrupt the underlying mechanisms of the class.
+   * <p>
+   * Please note that this {@code interrupt} method should be
+   * idempotent.  In other words, calling this {@code interrupt}
+   * method more than once should not have any side effect.
+   * </p>
    */
-  default void interrupt() {
-
-  }
+  void interrupt();
 
 }

--- a/src/main/java/ai/preferred/venom/Interruptible.java
+++ b/src/main/java/ai/preferred/venom/Interruptible.java
@@ -22,12 +22,10 @@ package ai.preferred.venom;
 public interface Interruptible extends AutoCloseable {
 
   /**
-   * Interrupt a thread and then close it.
-   *
-   * @throws Exception Exception.
+   * Interrupt the underlying mechanisms of the class.
    */
-  default void interruptAndClose() throws Exception {
-    close();
+  default void interrupt() {
+
   }
 
 }

--- a/src/main/java/ai/preferred/venom/ThreadedWorkerManager.java
+++ b/src/main/java/ai/preferred/venom/ThreadedWorkerManager.java
@@ -71,38 +71,25 @@ public class ThreadedWorkerManager implements WorkerManager {
   }
 
   @Override
-  public final void interruptAndClose() {
+  public final void interrupt() {
     if (executor == null) {
       return;
     }
-    LOGGER.debug("Forcefully shutting down the worker manager");
+    LOGGER.debug("Forcefully shutting down the worker manager.");
     executor.shutdownNow();
-    try {
-      executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
-      LOGGER.debug("The worker manager has been terminated");
-    } catch (final InterruptedException e) {
-      LOGGER.warn("Closing has been interrupted", e);
-      Thread.currentThread().interrupt();
-    }
   }
 
   @Override
-  public final void close() {
+  public final void close() throws InterruptedException {
     if (executor == null) {
       return;
     }
-    LOGGER.debug("Shutting down the worker manager");
+    LOGGER.debug("Shutting down the worker manager.");
     executor.shutdown();
-    try {
-      if (executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS)) {
-        LOGGER.debug("The worker manager has been terminated");
-      } else {
-        executor.shutdownNow();
-      }
-    } catch (final InterruptedException e) {
-      LOGGER.warn("Closing has been interrupted, forcefully shutting down", e);
+    if (executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS)) {
+      LOGGER.debug("The worker manager has been terminated.");
+    } else {
       executor.shutdownNow();
-      Thread.currentThread().interrupt();
     }
   }
 
@@ -120,7 +107,7 @@ public class ThreadedWorkerManager implements WorkerManager {
       final ManagedBlockerTask managedBlockerTask = new ManagedBlockerTask(task);
       try {
         ForkJoinPool.managedBlock(managedBlockerTask);
-      } catch (InterruptedException e) {
+      } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new AssertionError("Exception of unknown cause. Please verify codebase.", e);
       }

--- a/src/main/java/ai/preferred/venom/WorkerManager.java
+++ b/src/main/java/ai/preferred/venom/WorkerManager.java
@@ -21,7 +21,7 @@ import javax.validation.constraints.NotNull;
 /**
  * @author Maksim Tkachenko
  */
-public interface WorkerManager extends Interruptible {
+public interface WorkerManager extends Interruptible, AutoCloseable {
 
   /**
    * Get the result collector in use.

--- a/src/main/java/ai/preferred/venom/fetcher/Fetcher.java
+++ b/src/main/java/ai/preferred/venom/fetcher/Fetcher.java
@@ -16,7 +16,6 @@
 
 package ai.preferred.venom.fetcher;
 
-import ai.preferred.venom.Interruptible;
 import ai.preferred.venom.request.Request;
 import ai.preferred.venom.response.Response;
 
@@ -33,7 +32,7 @@ import java.util.concurrent.Future;
  * @author Truong Quoc Tuan
  * @author Ween Jiann Lee
  */
-public interface Fetcher extends Interruptible {
+public interface Fetcher extends AutoCloseable {
 
   /**
    * Fetcher starter.

--- a/src/test/java/ai/preferred/venom/ThreadedWorkerManagerTest.java
+++ b/src/test/java/ai/preferred/venom/ThreadedWorkerManagerTest.java
@@ -70,7 +70,7 @@ public class ThreadedWorkerManagerTest {
   }
 
   @Test
-  public void testInvokeNull() {
+  public void testInvokeNull() throws InterruptedException {
     try (final ThreadedWorkerManager threadedWorkerManager = new ThreadedWorkerManager(null)) {
       final Worker worker = threadedWorkerManager.getWorker();
       Assertions.assertTrue(worker instanceof ThreadedWorkerManager.ForkJoinWorker);

--- a/src/test/java/ai/preferred/venom/ThreadedWorkerManagerTest.java
+++ b/src/test/java/ai/preferred/venom/ThreadedWorkerManagerTest.java
@@ -70,7 +70,7 @@ public class ThreadedWorkerManagerTest {
   }
 
   @Test
-  public void testInvokeNull() throws InterruptedException {
+  public void testInvokeNull() {
     try (final ThreadedWorkerManager threadedWorkerManager = new ThreadedWorkerManager(null)) {
       final Worker worker = threadedWorkerManager.getWorker();
       Assertions.assertTrue(worker instanceof ThreadedWorkerManager.ForkJoinWorker);


### PR DESCRIPTION
Fixed bug so that it does not interrupt itself when calling interrupt from crawlerThread.